### PR TITLE
Remove size postfix from integer types

### DIFF
--- a/src/Types.php
+++ b/src/Types.php
@@ -6,8 +6,8 @@ class Types
 {
     // https://github.com/sandsmark/QuasselDroid/blob/master/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/qtcomm/QMetaType.java
     const TYPE_BOOL = 1;
-    const TYPE_INT32 = 2;
-    const TYPE_UINT32 = 3;
+    const TYPE_INT = 2;
+    const TYPE_UINT = 3;
     const TYPE_VARIANT_MAP = 8;
     const TYPE_VARIANT_LIST = 9;
     const TYPE_STRING = 10;
@@ -19,7 +19,7 @@ class Types
     public function getTypeByValue($value)
     {
         if (is_int($value)) {
-            return self::TYPE_INT32;
+            return self::TYPE_INT;
         } elseif (is_string($value)) {
             return self::TYPE_STRING;
         } elseif (is_bool($value)) {
@@ -37,8 +37,8 @@ class Types
     {
         static $map = array(
             Types::TYPE_BOOL => 'Bool',
-            Types::TYPE_INT32 => 'Int',
-            Types::TYPE_UINT32 => 'UInt',
+            Types::TYPE_INT => 'Int',
+            Types::TYPE_UINT => 'UInt',
             Types::TYPE_VARIANT_MAP => 'VariantMap',
             Types::TYPE_VARIANT_LIST => 'VariantList',
             Types::TYPE_STRING => 'String',

--- a/src/Writer.php
+++ b/src/Writer.php
@@ -38,12 +38,12 @@ class Writer
         }
     }
 
-    public function writeInt32($int)
+    public function writeInt($int)
     {
         $this->writer->writeInt32BE($int);
     }
 
-    public function writeUInt32($int)
+    public function writeUInt($int)
     {
         $this->writer->writeUInt32BE($int);
     }
@@ -101,9 +101,6 @@ class Writer
     public function writeVariantType($value, $type)
     {
         $name = 'write' . $this->types->getNameByType($type);
-        if ($type === Types::TYPE_INT32 || $type === Types::TYPE_UINT32) {
-            $name .= '32';
-        }
         if (!method_exists($this, $name)) {
             throw new \BadMethodCallException('Known variant type (' . $type . '), but has no "' . $name . '()" method');
         }

--- a/tests/WriterTest.php
+++ b/tests/WriterTest.php
@@ -29,7 +29,7 @@ class WriterTest extends TestCase
 
     public function testInteger()
     {
-        $this->writer->writeInt32(31);
+        $this->writer->writeInt(31);
         $this->assertEquals("\x00\x00\x00\x1F", (string)$this->writer);
     }
 
@@ -109,8 +109,8 @@ class WriterTest extends TestCase
 
     public function testIntegersConcatenated()
     {
-        $this->writer->writeInt32(0);
-        $this->writer->writeInt32(256);
+        $this->writer->writeInt(0);
+        $this->writer->writeInt(256);
         $this->assertEquals("\x00\x00\x00\x00" . "\x00\x00\x01\x00", (string)$this->writer);
     }
 


### PR DESCRIPTION
Remove size postfix from integer types
TYPE_(U)INT32 renamed to TYPE_(U)INT
write(U)Int32() renamed to write(U)Int()