### PR TITLE
Support Time and DateTime

### DIFF
--- a/src/Reader.php
+++ b/src/Reader.php
@@ -159,4 +159,37 @@ class Reader
 
         return $name($this);
     }
+
+    public function readTime()
+    {
+        $msec = $this->readUInt();
+        // TODO: losing sub-second precision here..
+        $secondsSinceMidnight = round($msec / 1000);
+
+        $dt = new \DateTime('midnight');
+        $dt->modify('+' . $secondsSinceMidnight . ' seconds');
+
+        return $dt;
+    }
+
+    public function readDateTime()
+    {
+        $day = $this->readUInt();
+        $msec = $this->readUInt();
+        $isUtc = $this->readBool();
+
+        if ($day === 0 && $msec === 0xFFFFFFFF) {
+            return null;
+        }
+
+        $daysSinceUnixEpoche = $day - 2440588; // unix epoche
+        // TODO: losing sub-second precision here..
+        $secondsSinceMidnight = round($msec / 1000);
+
+        $dt = new \DateTime('1970-01-01', $isUtc ? new \DateTimeZone('UTC') : null);
+        $dt->modify('+' . $daysSinceUnixEpoche . ' days');
+        $dt->modify('+' . $secondsSinceMidnight . ' seconds');
+
+        return $dt;
+    }
 }

--- a/src/Types.php
+++ b/src/Types.php
@@ -13,6 +13,8 @@ class Types
     const TYPE_STRING = 10;
     const TYPE_STRING_LIST = 11;
     const TYPE_BYTE_ARRAY = 12;
+    const TYPE_TIME = 15;
+    const TYPE_DATETIME = 16;
     const TYPE_USER_TYPE = 127;
     const TYPE_SHORT = 130;
     const TYPE_CHAR = 131;
@@ -31,6 +33,8 @@ class Types
             return self::TYPE_VARIANT_LIST;
         } elseif ($this->isMap($value)) {
             return self::TYPE_VARIANT_MAP;
+        } elseif ($value instanceof \DateTime) {
+            return self::TYPE_DATETIME;
         } else {
             throw new \InvalidArgumentException('Can not guess variant type for type "' . gettype($value) . '"');
         }
@@ -47,6 +51,8 @@ class Types
             Types::TYPE_STRING => 'String',
             Types::TYPE_STRING_LIST => 'StringList',
             Types::TYPE_BYTE_ARRAY => 'ByteArray',
+            Types::TYPE_TIME => 'Time',
+            Types::TYPE_DATETIME => 'DateTime',
             Types::TYPE_USER_TYPE => 'UserType',
             Types::TYPE_SHORT => 'Short',
             Types::TYPE_CHAR => 'Char',

--- a/src/Writer.php
+++ b/src/Writer.php
@@ -137,4 +137,27 @@ class Writer
             $this->writeVariant($value);
         }
     }
+
+    public function writeTime($timestamp)
+    {
+        if ($timestamp instanceof \DateTime) {
+            $timestamp = $timestamp->format('U.u');
+        }
+
+        $msec = round(($timestamp - strtotime('midnight')) * 1000);
+        $this->writer->writeUInt32BE($msec);
+    }
+
+    public function writeDateTime($timestamp)
+    {
+        if ($timestamp instanceof \DateTime) {
+            $timestamp = $timestamp->format('U.u');
+        }
+        $msec = round(($timestamp % 86400) * 1000);
+        $days = floor($timestamp / 86400) + 2440588;
+
+        $this->writer->writeUInt32BE($days);
+        $this->writer->writeUInt32BE($msec);
+        $this->writer->writeInt8(1);
+    }
 }

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -86,4 +86,86 @@ class FunctionalTest extends TestCase
         $this->assertEquals(-100, $reader->readChar());
         $this->assertEquals(250, $reader->readUChar());
     }
+
+    public function testReadTime()
+    {
+        $now = new \DateTime();
+
+        $writer = new Writer();
+        $writer->writeTime($now);
+
+        $in = (string)$writer;
+        $reader = Reader::fromString($in);
+
+        $dt = $reader->readTime();
+        $this->assertEquals($now, $dt);
+    }
+
+    public function testReadTimeSubSecond()
+    {
+        $this->markTestIncomplete('Sub-second accuracy not implemented');
+
+        $time = '2015-05-01 16:02:03.413705';
+        $now = new \DateTime($time);
+
+        $writer = new Writer();
+        $writer->writeTime($now);
+
+        $in = (string)$writer;
+        $reader = Reader::fromString($in);
+
+        $dt = $reader->readTime();
+        $this->assertEquals($now->format('U.u'), $dt->format('U.u'));
+    }
+
+    public function testReadTimeMicrotime()
+    {
+        $this->markTestIncomplete('Sub-second accuracy not implemented');
+
+        $now = microtime(true);
+
+        $writer = new Writer();
+        $writer->writeTime($now);
+
+        $in = (string)$writer;
+        $reader = Reader::fromString($in);
+
+        $dt = $reader->readTime();
+        $this->assertEquals($now, $dt->format('U.u'));
+    }
+
+    public function testReadDateTime()
+    {
+        $writer = new Writer();
+        $writer->writeUInt(2457136); // day 2457136 - 2015-04-23
+        $writer->writeUInt(50523000); // msec 50523000 - 14:02:03 UTC
+        $writer->writeBool(true);
+
+        $in = (string)$writer;
+        $reader = Reader::fromString($in);
+
+        $dt = $reader->readDateTime();
+        $this->assertEquals('2015-04-23 14:02:03', $dt->format('Y-m-d H:i:s'));
+
+        $writer = new Writer();
+        $writer->writeDateTime($dt);
+
+        $out = (string)$writer;
+
+        $this->assertEquals($in, $out);
+    }
+
+    public function testReadDateTimeNull()
+    {
+        $writer = new Writer();
+        $writer->writeUInt(0);
+        $writer->writeUInt(0xFFFFFFFF);
+        $writer->writeBool(true);
+
+        $in = (string)$writer;
+        $reader = Reader::fromString($in);
+
+        $dt = $reader->readDateTime();
+        $this->assertNull($dt);
+    }
 }

--- a/tests/TypesTest.php
+++ b/tests/TypesTest.php
@@ -31,6 +31,11 @@ class TypesTest extends TestCase
         $this->assertFalse($this->types->isMap(array(1, 'hello')));
     }
 
+    public function testTypeDateTime()
+    {
+        $this->assertEquals(Types::TYPE_DATETIME, $this->types->getTypeByValue(new \DateTime()));
+    }
+
     /**
      * @expectedException InvalidArgumentException
      */


### PR DESCRIPTION
* Write: A `DateTime` object will always be serialized as a "QDateTime", never as a "QTime"
* Write: Both accept either timestamps (either `time()` or `microtime(true)` for higher accuracy) or `DateTime` objects
* Read: Both will  be always be parsed into a `DateTime`
* Read: Both will *not* include sub-second accuracy and will round to full seconds