### PR TITLE
Merge writeVariantType() into writeVariant()

### DIFF
--- a/src/Writer.php
+++ b/src/Writer.php
@@ -103,13 +103,18 @@ class Writer
         $this->writer->writeUInt8($value ? 1 : 0);
     }
 
-    public function writeVariant($value)
+    public function writeVariant($value, $type = null)
     {
-        $this->writeVariantType($value, $this->types->getTypeByValue($value));
-    }
+        if ($type === null) {
+            $type = $this->types->getTypeByValue($value);
+        }
 
-    public function writeVariantType($value, $type)
-    {
+        if (is_string($type)) {
+            $this->writeType(Types::TYPE_USER_TYPE);
+
+            return $this->writeUserTypeByName($value, $type);
+        }
+
         $name = 'write' . $this->types->getNameByType($type);
         if (!method_exists($this, $name)) {
             throw new \BadMethodCallException('Known variant type (' . $type . '), but has no "' . $name . '()" method');

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -2,6 +2,7 @@
 
 use Clue\QDataStream\Reader;
 use Clue\QDataStream\Writer;
+use Clue\QDataStream\Types;
 
 class FunctionalTest extends TestCase
 {
@@ -43,6 +44,19 @@ class FunctionalTest extends TestCase
 
         $writer = new Writer();
         $writer->writeVariant($in);
+
+        $data = (string)$writer;
+        $reader = Reader::fromString($data);
+
+        $this->assertEquals($in, $reader->readVariant());
+    }
+
+    public function testVariantExplicitCharType()
+    {
+        $in = 100;
+
+        $writer = new Writer();
+        $writer->writeVariant($in, Types::TYPE_CHAR);
 
         $data = (string)$writer;
         $reader = Reader::fromString($data);

--- a/tests/WriterTest.php
+++ b/tests/WriterTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Clue\QDataStream\Writer;
+use Clue\QDataStream\Types;
 
 class WriterTest extends TestCase
 {
@@ -97,6 +98,12 @@ class WriterTest extends TestCase
     {
         $this->writer->writeVariant('Hi');
         $this->assertEquals("\x00\x00\x00\x0A\x00" . "\x00\x00\x00\x04" . "\x00H\x00i", (string)$this->writer);
+    }
+
+    public function testVariantExplicit()
+    {
+        $this->writer->writeVariant(2015, Types::TYPE_USHORT);
+        $this->assertEquals("\x00\x00\x00\x85\x00" . "\x07\xDF", (string)$this->writer);
     }
 
     /**


### PR DESCRIPTION
Type can (optionally) be given and defaults to auto detection.
Simplifies writing explict/custom variant types.
This is now also in line with reading.