### PR TITLE
Support passing explicit types to variant list and map

### DIFF
--- a/src/Writer.php
+++ b/src/Writer.php
@@ -124,22 +124,28 @@ class Writer
         $this->$name($value);
     }
 
-    public function writeVariantList(array $list)
+    public function writeVariantList(array $list, $explicitTypes = array())
     {
         $this->writer->writeUInt32BE(count($list));
 
-        foreach ($list as $value) {
-            $this->writeVariant($value);
+        foreach ($list as $index => $value) {
+            $this->writeVariant(
+                $value,
+                isset($explicitTypes[$index]) ? $explicitTypes[$index] : null
+            );
         }
     }
 
-    public function writeVariantMap(array $map)
+    public function writeVariantMap(array $map, $explicitTypes = array())
     {
         $this->writer->writeUInt32BE(count($map));
 
         foreach ($map as $key => $value) {
             $this->writeString($key);
-            $this->writeVariant($value);
+            $this->writeVariant(
+                $value,
+                isset($explicitTypes[$key]) ? $explicitTypes[$key] : null
+            );
         }
     }
 

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -64,6 +64,39 @@ class FunctionalTest extends TestCase
         $this->assertEquals($in, $reader->readVariant());
     }
 
+    public function testVariantListSomeExplicit()
+    {
+        $in = array(
+            -10,
+            20,
+            -300
+        );
+
+        $writer = new Writer();
+        $writer->writeVariantList($in, array(0 => Types::TYPE_CHAR));
+
+        $data = (string)$writer;
+        $reader = Reader::fromString($data);
+
+        $this->assertEquals($in, $reader->readVariantList());
+    }
+
+    public function testVariantMapSomeExplicit()
+    {
+        $in = array(
+            'id' => 62000,
+            'name' => 'test'
+        );
+
+        $writer = new Writer();
+        $writer->writeVariantMap($in, array('id' => Types::TYPE_USHORT));
+
+        $data = (string)$writer;
+        $reader = Reader::fromString($data);
+
+        $this->assertEquals($in, $reader->readVariantMap());
+    }
+
     public function testStringList()
     {
         $writer = new Writer();


### PR DESCRIPTION
Passing explicit types to lists and maps is now in line with individual variants (#9)