### PR TITLE
QTime and QDateTime are relative to default time zone and obey given time zone

### DIFF
--- a/src/Reader.php
+++ b/src/Reader.php
@@ -176,6 +176,15 @@ class Reader
         return $name($this);
     }
 
+    /**
+     * Reads a QTime from the stream and returns a DateTime with current timezone
+     *
+     * The QTime will be sent as the number of milliseconds since midnight,
+     * without any awareness of timezone or DST properties. Thus, reading this
+     * in will assume it is relative to the current timezone.
+     *
+     * @return \DateTime
+     */
     public function readQTime()
     {
         $msec = $this->readUInt();
@@ -188,6 +197,11 @@ class Reader
         return $dt;
     }
 
+    /**
+     * Reads a QDateTime from the stream and returns a DateTime with current timezone
+     *
+     * @return \DateTime|NULL
+     */
     public function readQDateTime()
     {
         $day = $this->readUInt();
@@ -205,6 +219,9 @@ class Reader
         $dt = new \DateTime('1970-01-01', $isUtc ? new \DateTimeZone('UTC') : null);
         $dt->modify('+' . $daysSinceUnixEpoche . ' days');
         $dt->modify('+' . $secondsSinceMidnight . ' seconds');
+
+        // apply default timezone after jumping to correct date (account for DST)
+        $dt->setTimezone(new \DateTimeZone(date_default_timezone_get()));
 
         return $dt;
     }

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -224,6 +224,8 @@ class FunctionalTest extends TestCase
 
     public function testReadQTimeNow()
     {
+        date_default_timezone_set('UTC');
+
         $now = new \DateTime();
 
         $writer = new Writer();
@@ -236,8 +238,28 @@ class FunctionalTest extends TestCase
         $this->assertEquals($now, $dt);
     }
 
+    public function testReadQTimeNowCorrectTimezone()
+    {
+        date_default_timezone_set('Europe/Berlin');
+
+        $now = new \DateTime();
+
+        $writer = new Writer();
+        $writer->writeQTime($now);
+
+        $in = (string)$writer;
+        $reader = Reader::fromString($in);
+
+        $dt = $reader->readQTime();
+        $this->assertEquals($now, $dt);
+
+        $this->assertEquals('Europe/Berlin', $dt->getTimezone()->getName());
+    }
+
     public function testReadQTimeNotTodayCanNotReturnDayInPast()
     {
+        date_default_timezone_set('UTC');
+
         $time = '2015-05-01 16:02:03';
         $now = new \DateTime($time);
 
@@ -254,6 +276,8 @@ class FunctionalTest extends TestCase
     public function testReadQTimeSubSecond()
     {
         $this->markTestIncomplete('Sub-second accuracy not implemented');
+
+        date_default_timezone_set('UTC');
 
         $time = '2015-05-01 16:02:03.413705';
         $now = new \DateTime($time);
@@ -272,6 +296,8 @@ class FunctionalTest extends TestCase
     {
         $this->markTestIncomplete('Sub-second accuracy not implemented');
 
+        date_default_timezone_set('UTC');
+
         $now = microtime(true);
 
         $writer = new Writer();
@@ -284,8 +310,61 @@ class FunctionalTest extends TestCase
         $this->assertEquals($now, $dt->format('U.u'));
     }
 
+    public function testReadQDateTimeNow()
+    {
+        date_default_timezone_set('UTC');
+
+        $now = new \DateTime();
+
+        $writer = new Writer();
+        $writer->writeQDateTime($now);
+
+        $in = (string)$writer;
+        $reader = Reader::fromString($in);
+
+        $dt = $reader->readQDateTime();
+        $this->assertEquals($now, $dt);
+    }
+
+    public function testReadQDateTimeNowWithCorrectTimezone()
+    {
+        date_default_timezone_set('Europe/Berlin');
+
+        $now = new \DateTime();
+
+        $writer = new Writer();
+        $writer->writeQDateTime($now);
+
+        $in = (string)$writer;
+        $reader = Reader::fromString($in);
+
+        $dt = $reader->readQDateTime();
+        $this->assertEquals($now, $dt);
+
+        $this->assertEquals('Europe/Berlin', $dt->getTimezone()->getName());
+    }
+
+    public function testReadQDateTimeWithDST()
+    {
+        date_default_timezone_set('Europe/Berlin');
+
+        $now = '2015-09-22 09:45:12';
+        $now = new \DateTime($now);
+
+        $writer = new Writer();
+        $writer->writeQDateTime($now);
+
+        $in = (string)$writer;
+        $reader = Reader::fromString($in);
+
+        $dt = $reader->readQDateTime();
+        $this->assertEquals($now, $dt);
+    }
+
     public function testReadQDateTime()
     {
+        date_default_timezone_set('UTC');
+
         $writer = new Writer();
         $writer->writeUInt(2457136); // day 2457136 - 2015-04-23
         $writer->writeUInt(50523000); // msec 50523000 - 14:02:03 UTC
@@ -307,6 +386,8 @@ class FunctionalTest extends TestCase
 
     public function testReadQDateTimeNull()
     {
+        date_default_timezone_set('UTC');
+
         $writer = new Writer();
         $writer->writeUInt(0);
         $writer->writeUInt(0xFFFFFFFF);

--- a/tests/ReaderTest.php
+++ b/tests/ReaderTest.php
@@ -24,6 +24,36 @@ class ReaderTest extends TestCase
         return Reader::fromString($in, null, $map);
     }
 
+    public function testReadNullQTimeIsExactlyMidnight()
+    {
+        date_default_timezone_set('UTC');
+
+        $midnight = new DateTime('midnight');
+
+        $in = "\x00\x00\x00\x00";
+        $reader = Reader::fromString($in);
+
+        $value = $reader->readQTime();
+
+        $this->assertEquals($midnight, $value);
+    }
+
+    public function testReadNullQTimeIsExactlyMidnightWithCorrectTimezone()
+    {
+        date_default_timezone_set('Europe/Berlin');
+
+        $midnight = new DateTime('midnight');
+
+        $in = "\x00\x00\x00\x00";
+        $reader = Reader::fromString($in);
+
+        $value = $reader->readQTime();
+
+        $this->assertEquals($midnight, $value);
+
+        $this->assertEquals('Europe/Berlin', $value->getTimezone()->getName());
+    }
+
     /**
      * @depends testUserTypeMapping
      * @param Reader $reader

--- a/tests/WriterTest.php
+++ b/tests/WriterTest.php
@@ -99,6 +99,29 @@ class WriterTest extends TestCase
         $this->assertEquals("\x00\x00\x00\x00", (string)$this->writer);
     }
 
+    public function testQTimeExactlyMidnightIsNullMillisecondsFromForeignTimezone()
+    {
+        date_default_timezone_set('Europe/Berlin');
+
+        $now = new DateTime();
+        $now->setTime(0, 0, 0);
+
+        date_default_timezone_set('UTC');
+
+        $this->writer->writeQTime($now);
+        $this->assertEquals("\x00\x00\x00\x00", (string)$this->writer);
+    }
+
+    public function testQTimeMillisecondsAfterMidnight()
+    {
+        date_default_timezone_set('UTC');
+
+        $now = gmmktime(0, 0, 0, 9, 19, 2016) + 0.018;
+
+        $this->writer->writeQTime($now);
+        $this->assertEquals("\x00\x00\x00\x12", (string)$this->writer);
+    }
+
     public function testQVariantBoolTrue()
     {
         $this->writer->writeQVariant(true);

--- a/tests/WriterTest.php
+++ b/tests/WriterTest.php
@@ -81,6 +81,18 @@ class WriterTest extends TestCase
 
     public function testQTimeExactlyMidnightIsNullMilliseconds()
     {
+        date_default_timezone_set('UTC');
+
+        $now = gmmktime(0, 0, 0, 9, 19, 2016);
+
+        $this->writer->writeQTime($now);
+        $this->assertEquals("\x00\x00\x00\x00", (string)$this->writer);
+    }
+
+    public function testQTimeExactlyMidnightIsNullMillisecondsWithTimezone()
+    {
+        date_default_timezone_set('Europe/Berlin');
+
         $now = mktime(0, 0, 0, 9, 19, 2016);
 
         $this->writer->writeQTime($now);


### PR DESCRIPTION
* Writing via `writeQTime()` now obeys the given time zone and sends a value relative to midnight in this time zone
* Reading via either `readQTime()` or  `readQDateTime()` now always return `DateTime` objects relative to the default time zone. This used to be inconsistent in previous releases and is now explicitly enforced.