### PR TITLE
Simplify Reader and Writer and remove dependency on Iodophor

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,71 @@
 
 > Note: This project is in beta stage! Feel free to report any issues you encounter.
 
+## Usage
+
+### Writer
+
+The `Writer` class can be used to build a buffer that data can be written to
+and eventually be accessed as a binary string.
+
+```php
+$writer = new Writer();
+$writer->writeUInt($user->id);
+$writer->writeBool($user->active);
+$writer->writeQString($user->name);
+
+$data = (string)$writer
+file_put_contents('user.dat', $data);
+```
+
+See the [class outline](src/Writer.php) for more details.
+
+### Reader
+
+The `Reader` class can be used to read data from a binary buffer string.
+
+```php
+$data = file_get_contents('user.dat');
+$reader = new Reader($data);
+
+$user = new stdClass();
+$user->id = $reader->readUInt();
+$user->active = $reader->readBool();
+$user->name = $reader->readQString();
+```
+
+See the [class outline](src/Reader.php) for more details.
+
+### QVariant
+
+The `QVariant` class can be used to encapsulate any kind of data with an
+explicit data type. When writing a `QVariant` to a buffer, it will also
+include its data type so that reading it back in can be done automatically
+without having to know the data type in advance.
+
+```php
+$variant = new QVariant(100, Types::TYPE_USHORT);
+
+$writer = new Writer();
+$writer->writeQVariant($variant);
+
+$data = (string)$writer;
+$reader = new Reader($data);
+$value = $reader->readQVariant();
+
+assert($value === 100);
+```
+
+See the [class outline](src/QVariant.php) for more details.
+
+### Types
+
+The `Types` class exists to work with different data types and offers a number
+of public constants to work with explicit data types and is otherwise mostly
+used internally only.
+
+See the [class outline](src/Types.php) for more details.
+
 ## Install
 
 The recommended way to install this library is [through Composer](http://getcomposer.org).

--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,7 @@
         "psr-4": { "Clue\\QDataStream\\": "src/" }
     },
     "require": {
-    	"php": ">=5.3",
-        "e-butik/iodophor": "~1.0"
+        "php": ">=5.3"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.0 || ^4.8"

--- a/src/Reader.php
+++ b/src/Reader.php
@@ -2,9 +2,6 @@
 
 namespace Clue\QDataStream;
 
-use Iodophor\Io\Reader as IoReader;
-use Iodophor\Io\StringReader;
-
 class Reader
 {
     private $types;
@@ -12,18 +9,13 @@ class Reader
     private $hasNull = true;
     private $buffer = '';
 
-    public static function fromString($str, Types $types = null, $userTypeMap = array())
-    {
-        return new self(new StringReader($str), $types, $userTypeMap);
-    }
-
-    public function __construct(IoReader $reader, Types $types = null, $userTypeMap = array())
+    public function __construct($buffer, Types $types = null, $userTypeMap = array())
     {
         if ($types === null) {
             $types = new Types();
         }
 
-        $this->buffer = $reader->read($reader->getSize());
+        $this->buffer = $buffer;
         $this->types = $types;
         $this->userTypeMap = $userTypeMap;
     }

--- a/src/Types.php
+++ b/src/Types.php
@@ -22,6 +22,13 @@ class Types
     const TYPE_USHORT = 133;
     const TYPE_UCHAR = 134;
 
+    /**
+     * Tries to guess the type constant based on the data type of the given value
+     *
+     * @param mixed $value
+     * @return int see TYPE_* constants
+     * @throws \InvalidArgumentException if type can not be guessed
+     */
     public function getTypeByValue($value)
     {
         if (is_int($value)) {
@@ -76,6 +83,14 @@ class Types
         return $map[$type];
     }
 
+    /**
+     * Checks whether the given argument is a list (vector array)
+     *
+     * An empty array is considered both a list and a map.
+     *
+     * @param mixed $array
+     * @return bool
+     */
     public function isList($array)
     {
         if (!is_array($array)) {
@@ -91,6 +106,14 @@ class Types
         return true;
     }
 
+    /**
+     * Checks whether the given argument is a map (hash map / assoc array)
+     *
+     * An empty array is considered both a list and a map.
+     *
+     * @param array $array
+     * @return boolean
+     */
     public function isMap($array)
     {
         return ($array === array() || (is_array($array) && !$this->isList($array)));

--- a/src/Writer.php
+++ b/src/Writer.php
@@ -2,8 +2,6 @@
 
 namespace Clue\QDataStream;
 
-use Iodophor\Io\StringWriter as IoWriter;
-
 // http://doc.qt.io/qt-4.8/qdatastream.html#details
 class Writer
 {
@@ -13,7 +11,7 @@ class Writer
 
     private $buffer = '';
 
-    public function __construct(IoWriter $_ = null, Types $types = null, $userTypeMap = array())
+    public function __construct(Types $types = null, $userTypeMap = array())
     {
         if ($types === null) {
             $types = new Types();

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -15,7 +15,7 @@ class FunctionalTest extends TestCase
         $writer->writeQString($in);
 
         $data = (string)$writer;
-        $reader = Reader::fromString($data);
+        $reader = new Reader($data);
 
         $this->assertEquals($in, $reader->readQString());
     }
@@ -26,7 +26,7 @@ class FunctionalTest extends TestCase
         $writer->writeQString('');
 
         $data = (string)$writer;
-        $reader = Reader::fromString($data);
+        $reader = new Reader($data);
 
         $this->assertEquals('', $reader->readQString());
     }
@@ -37,7 +37,7 @@ class FunctionalTest extends TestCase
         $writer->writeQString(null);
 
         $data = (string)$writer;
-        $reader = Reader::fromString($data);
+        $reader = new Reader($data);
 
         $this->assertEquals(null, $reader->readQString());
     }
@@ -58,11 +58,11 @@ class FunctionalTest extends TestCase
         $writer->writeQVariant($in);
 
         $data = (string)$writer;
-        $reader = Reader::fromString($data);
+        $reader = new Reader($data);
 
         $this->assertEquals($in, $reader->readQVariant());
 
-        return Reader::fromString($data);
+        return new Reader($data);
     }
 
     /**
@@ -93,7 +93,7 @@ class FunctionalTest extends TestCase
         $writer->writeQVariant(new QVariant($in, Types::TYPE_CHAR));
 
         $data = (string)$writer;
-        $reader = Reader::fromString($data);
+        $reader = new Reader($data);
 
         $this->assertEquals($in, $reader->readQVariant());
     }
@@ -106,7 +106,7 @@ class FunctionalTest extends TestCase
         $writer->writeQVariant(new QVariant($in, Types::TYPE_QCHAR));
 
         $data = (string)$writer;
-        $reader = Reader::fromString($data);
+        $reader = new Reader($data);
 
         $this->assertEquals($in, $reader->readQVariant());
     }
@@ -129,7 +129,7 @@ class FunctionalTest extends TestCase
 
         $data = (string)$writer;
 
-        $reader = Reader::fromString($data);
+        $reader = new Reader($data);
         $this->assertEquals($expected, $reader->readQVariantList());
     }
 
@@ -148,7 +148,7 @@ class FunctionalTest extends TestCase
         $writer->writeQVariantMap($in);
 
         $data = (string)$writer;
-        $reader = Reader::fromString($data);
+        $reader = new Reader($data);
 
         $this->assertEquals($expected, $reader->readQVariantMap());
     }
@@ -160,7 +160,7 @@ class FunctionalTest extends TestCase
             'name' => 'test'
         );
 
-        $writer = new Writer(null, null, array(
+        $writer = new Writer(null, array(
             'user' => function ($data, Writer $writer) {
                 $writer->writeUShort($data['id']);
                 $writer->writeQString($data['name']);
@@ -169,7 +169,7 @@ class FunctionalTest extends TestCase
         $writer->writeQVariant(new QVariant($in, 'user'));
 
         $data = (string)$writer;
-        $reader = Reader::fromString($data, null, array(
+        $reader = new Reader($data, null, array(
             'user' => function (Reader $reader) {
                 return array(
                     'id' => $reader->readUShort(),
@@ -187,11 +187,11 @@ class FunctionalTest extends TestCase
         $writer->writeQStringList(array('hello', 'world'));
 
         $data = (string)$writer;
-        $reader = Reader::fromString($data);
+        $reader = new Reader($data);
 
         $this->assertEquals(array('hello', 'world'), $reader->readQStringList());
 
-        return Reader::fromString($data);
+        return new Reader($data);
     }
 
     public function testQCharMultiple()
@@ -201,7 +201,7 @@ class FunctionalTest extends TestCase
         $writer->writeQChar('ä');
 
         $data = (string)$writer;
-        $reader = Reader::fromString($data);
+        $reader = new Reader($data);
 
         $this->assertEquals('a', $reader->readQChar());
         $this->assertEquals('ä', $reader->readQChar());
@@ -214,7 +214,7 @@ class FunctionalTest extends TestCase
         $writer->writeUShort(60000);
 
         $data = (string)$writer;
-        $reader = Reader::fromString($data);
+        $reader = new Reader($data);
 
         $this->assertEquals(-100, $reader->readShort());
         $this->assertEquals(60000, $reader->readUShort());
@@ -227,7 +227,7 @@ class FunctionalTest extends TestCase
         $writer->writeUChar(250);
 
         $data = (string)$writer;
-        $reader = Reader::fromString($data);
+        $reader = new Reader($data);
 
         $this->assertEquals(-100, $reader->readChar());
         $this->assertEquals(250, $reader->readUChar());
@@ -243,7 +243,7 @@ class FunctionalTest extends TestCase
         $writer->writeQTime($now);
 
         $in = (string)$writer;
-        $reader = Reader::fromString($in);
+        $reader = new Reader($in);
 
         $dt = $reader->readQTime();
         $this->assertEquals($now, $dt);
@@ -259,7 +259,7 @@ class FunctionalTest extends TestCase
         $writer->writeQTime($now);
 
         $in = (string)$writer;
-        $reader = Reader::fromString($in);
+        $reader = new Reader($in);
 
         $dt = $reader->readQTime();
         $this->assertEquals($now, $dt);
@@ -278,7 +278,7 @@ class FunctionalTest extends TestCase
         $writer->writeQTime($now);
 
         $in = (string)$writer;
-        $reader = Reader::fromString($in);
+        $reader = new Reader($in);
 
         $dt = $reader->readQTime();
         $this->assertNotEquals($now->format('U.u'), $dt->format('U.u'));
@@ -295,7 +295,7 @@ class FunctionalTest extends TestCase
         $writer->writeQTime($now);
 
         $in = (string)$writer;
-        $reader = Reader::fromString($in);
+        $reader = new Reader($in);
 
         $dt = $reader->readQTime();
         $this->assertEquals($now->format('U.u'), $dt->format('U.u'));
@@ -311,7 +311,7 @@ class FunctionalTest extends TestCase
         $writer->writeQTime($now);
 
         $in = (string)$writer;
-        $reader = Reader::fromString($in);
+        $reader = new Reader($in);
 
         $dt = $reader->readQTime();
         $this->assertEquals($now, $dt->format('U.u'), '', 0.001);
@@ -327,7 +327,7 @@ class FunctionalTest extends TestCase
         $writer->writeQDateTime($now);
 
         $in = (string)$writer;
-        $reader = Reader::fromString($in);
+        $reader = new Reader($in);
 
         $dt = $reader->readQDateTime();
         $this->assertEquals($now, $dt);
@@ -343,7 +343,7 @@ class FunctionalTest extends TestCase
         $writer->writeQDateTime($now);
 
         $in = (string)$writer;
-        $reader = Reader::fromString($in);
+        $reader = new Reader($in);
 
         $dt = $reader->readQDateTime();
         $this->assertEquals($now, $dt);
@@ -362,7 +362,7 @@ class FunctionalTest extends TestCase
         $writer->writeQDateTime($now);
 
         $in = (string)$writer;
-        $reader = Reader::fromString($in);
+        $reader = new Reader($in);
 
         $dt = $reader->readQDateTime();
         $this->assertEquals($now, $dt);
@@ -378,7 +378,7 @@ class FunctionalTest extends TestCase
         $writer->writeBool(true);
 
         $in = (string)$writer;
-        $reader = Reader::fromString($in);
+        $reader = new Reader($in);
 
         $dt = $reader->readQDateTime();
         $this->assertEquals('2015-04-23 14:02:03', $dt->format('Y-m-d H:i:s'));
@@ -401,7 +401,7 @@ class FunctionalTest extends TestCase
         $writer->writeBool(true);
 
         $in = (string)$writer;
-        $reader = Reader::fromString($in);
+        $reader = new Reader($in);
 
         $dt = $reader->readQDateTime();
         $this->assertNull($dt);
@@ -418,7 +418,7 @@ class FunctionalTest extends TestCase
         $writer->writeQDateTime($now);
 
         $in = (string)$writer;
-        $reader = Reader::fromString($in);
+        $reader = new Reader($in);
 
         $dt = $reader->readQDateTime();
         $this->assertEquals($now->format('U.u'), $dt->format('U.u'));
@@ -434,7 +434,7 @@ class FunctionalTest extends TestCase
         $writer->writeQDateTime($now);
 
         $in = (string)$writer;
-        $reader = Reader::fromString($in);
+        $reader = new Reader($in);
 
         $dt = $reader->readQDateTime();
         $this->assertEquals($now, $dt->format('U.u'), '', 0.001);

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -20,6 +20,17 @@ class FunctionalTest extends TestCase
         $this->assertEquals($in, $reader->readQString());
     }
 
+    public function testQStringEmpty()
+    {
+        $writer = new Writer();
+        $writer->writeQString('');
+
+        $data = (string)$writer;
+        $reader = Reader::fromString($data);
+
+        $this->assertEquals('', $reader->readQString());
+    }
+
     public function testQStringNull()
     {
         $writer = new Writer();

--- a/tests/ReaderTest.php
+++ b/tests/ReaderTest.php
@@ -64,6 +64,17 @@ class ReaderTest extends TestCase
     }
 
     /**
+     * @expectedException UnderflowException
+     */
+    public function testReadBeyondLimitThrows()
+    {
+        $in = "\x00\x00";
+
+        $reader = Reader::fromString($in);
+        $reader->readInt();
+    }
+
+    /**
      * @expectedException UnexpectedValueException
      */
     public function testQUserTypeUnknown()

--- a/tests/ReaderTest.php
+++ b/tests/ReaderTest.php
@@ -15,13 +15,13 @@ class ReaderTest extends TestCase
             }
         );
 
-        $reader = Reader::fromString($in, null, $map);
+        $reader = new Reader($in, null, $map);
 
         $value = $reader->readQVariant();
 
         $this->assertEquals(255, $value);
 
-        return Reader::fromString($in, null, $map);
+        return new Reader($in, null, $map);
     }
 
     public function testReadNullQTimeIsExactlyMidnight()
@@ -31,7 +31,7 @@ class ReaderTest extends TestCase
         $midnight = new DateTime('midnight');
 
         $in = "\x00\x00\x00\x00";
-        $reader = Reader::fromString($in);
+        $reader = new Reader($in);
 
         $value = $reader->readQTime();
 
@@ -45,7 +45,7 @@ class ReaderTest extends TestCase
         $midnight = new DateTime('midnight');
 
         $in = "\x00\x00\x00\x00";
-        $reader = Reader::fromString($in);
+        $reader = new Reader($in);
 
         $value = $reader->readQTime();
 
@@ -70,7 +70,7 @@ class ReaderTest extends TestCase
     {
         $in = "\x00\x00";
 
-        $reader = Reader::fromString($in);
+        $reader = new Reader($in);
         $reader->readInt();
     }
 
@@ -81,7 +81,7 @@ class ReaderTest extends TestCase
     {
         $in = "\x00\x00\x00\x7F" . "\x00" . "\x00\x00\x00\x05" . "demo\x00" . "\x00\x00\x00\xFF";
 
-        $reader = Reader::fromString($in);
+        $reader = new Reader($in);
         $reader->readQVariant();
     }
 }

--- a/tests/WriterTest.php
+++ b/tests/WriterTest.php
@@ -8,7 +8,7 @@ class WriterTest extends TestCase
 {
     public function setUp()
     {
-        $this->writer = new Writer(null, null, array(
+        $this->writer = new Writer(null, array(
             'year' => function ($data, Writer $writer) {
                 $writer->writeUShort($data);
             },


### PR DESCRIPTION
The BC break mostly affects how the `Reader` and `Writer` now directly work on a buffer string instead of exposing Iodophor as a dependency.

```php
// old
$reader = Reader::fromString($buffer, $types, $map);
$writer = new Writer($writer, $types, $map);

// new
$reader = new Reader($buffer, $types, $map);
$writer = new Writer($types, $map);
```

Also resolves / closes #15