### PR TITLE
Simplify Types to be static only

### DIFF
--- a/src/Reader.php
+++ b/src/Reader.php
@@ -4,24 +4,16 @@ namespace Clue\QDataStream;
 
 class Reader
 {
-    private $types;
+    private $buffer = '';
     private $userTypeMap;
     private $hasNull = true;
-    private $buffer = '';
-
     /**
-     * @param string     $buffer
-     * @param Types|null $types
-     * @param array      $userTypeMap
+     * @param string $buffer
+     * @param array  $userTypeMap
      */
-    public function __construct($buffer, Types $types = null, $userTypeMap = array())
+    public function __construct($buffer, $userTypeMap = array())
     {
-        if ($types === null) {
-            $types = new Types();
-        }
-
         $this->buffer = $buffer;
-        $this->types = $types;
         $this->userTypeMap = $userTypeMap;
     }
 
@@ -40,7 +32,7 @@ class Reader
             /*$isNull = */ $this->readBool();
         }
 
-        $name = 'read' . $this->types->getNameByType($type);
+        $name = 'read' . Types::getNameByType($type);
         if (!method_exists($this, $name)) {
             throw new \BadMethodCallException('Known variant type (' . $type . '), but has no "' . $name . '()" method'); // @codeCoverageIgnore
         }

--- a/src/Types.php
+++ b/src/Types.php
@@ -2,7 +2,7 @@
 
 namespace Clue\QDataStream;
 
-class Types
+final class Types
 {
     // https://github.com/sandsmark/QuasselDroid/blob/master/QuasselDroid/src/main/java/com/iskrembilen/quasseldroid/qtcomm/QMetaType.java
     const TYPE_BOOL = 1;
@@ -29,7 +29,7 @@ class Types
      * @return int see TYPE_* constants
      * @throws \InvalidArgumentException if type can not be guessed
      */
-    public function getTypeByValue($value)
+    public static function getTypeByValue($value)
     {
         if (is_int($value)) {
             return self::TYPE_INT;
@@ -37,9 +37,9 @@ class Types
             return self::TYPE_QSTRING;
         } elseif (is_bool($value)) {
             return self::TYPE_BOOL;
-        } elseif ($this->isList($value)) {
+        } elseif (self::isList($value)) {
             return self::TYPE_QVARIANT_LIST;
-        } elseif ($this->isMap($value)) {
+        } elseif (self::isMap($value)) {
             return self::TYPE_QVARIANT_MAP;
         } elseif ($value instanceof \DateTime) {
             return self::TYPE_QDATETIME;
@@ -55,7 +55,7 @@ class Types
      * @return string
      * @throws \InvalidArgumentException
      */
-    public function getNameByType($type)
+    public static function getNameByType($type)
     {
         static $map = array(
             self::TYPE_BOOL => 'Bool',
@@ -91,7 +91,7 @@ class Types
      * @param mixed $array
      * @return bool
      */
-    public function isList($array)
+    public static function isList($array)
     {
         if (!is_array($array)) {
             return false;
@@ -114,8 +114,8 @@ class Types
      * @param array $array
      * @return boolean
      */
-    public function isMap($array)
+    public static function isMap($array)
     {
-        return ($array === array() || (is_array($array) && !$this->isList($array)));
+        return ($array === array() || (is_array($array) && !self::isList($array)));
     }
 }

--- a/src/Writer.php
+++ b/src/Writer.php
@@ -5,23 +5,16 @@ namespace Clue\QDataStream;
 // http://doc.qt.io/qt-4.8/qdatastream.html#details
 class Writer
 {
-    private $types;
     private $userTypeMap;
     private $hasNull = true;
 
     private $buffer = '';
 
     /**
-     * @param Types|null $types
-     * @param array      $userTypeMap
+     * @param array $userTypeMap
      */
-    public function __construct(Types $types = null, $userTypeMap = array())
+    public function __construct($userTypeMap = array())
     {
-        if ($types === null) {
-            $types = new Types();
-        }
-
-        $this->types = $types;
         $this->userTypeMap = $userTypeMap;
     }
 
@@ -169,7 +162,7 @@ class Writer
             $type = $value->getType();
             $value = $value->getValue();
         } else {
-            $type = $this->types->getTypeByValue($value);
+            $type = Types::getTypeByValue($value);
         }
 
         if (is_string($type)) {
@@ -178,7 +171,7 @@ class Writer
             return $this->writeQUserTypeByName($value, $type);
         }
 
-        $name = 'write' . $this->types->getNameByType($type);
+        $name = 'write' . Types::getNameByType($type);
         if (!method_exists($this, $name)) {
             throw new \BadMethodCallException('Known variant type (' . $type . '), but has no "' . $name . '()" method'); // @codeCoverageIgnore
         }

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -160,7 +160,7 @@ class FunctionalTest extends TestCase
             'name' => 'test'
         );
 
-        $writer = new Writer(null, array(
+        $writer = new Writer(array(
             'user' => function ($data, Writer $writer) {
                 $writer->writeUShort($data['id']);
                 $writer->writeQString($data['name']);
@@ -169,7 +169,7 @@ class FunctionalTest extends TestCase
         $writer->writeQVariant(new QVariant($in, 'user'));
 
         $data = (string)$writer;
-        $reader = new Reader($data, null, array(
+        $reader = new Reader($data, array(
             'user' => function (Reader $reader) {
                 return array(
                     'id' => $reader->readUShort(),

--- a/tests/ReaderTest.php
+++ b/tests/ReaderTest.php
@@ -15,13 +15,13 @@ class ReaderTest extends TestCase
             }
         );
 
-        $reader = new Reader($in, null, $map);
+        $reader = new Reader($in, $map);
 
         $value = $reader->readQVariant();
 
         $this->assertEquals(255, $value);
 
-        return new Reader($in, null, $map);
+        return new Reader($in, $map);
     }
 
     public function testReadNullQTimeIsExactlyMidnight()

--- a/tests/TypesTest.php
+++ b/tests/TypesTest.php
@@ -4,36 +4,31 @@ use Clue\QDataStream\Types;
 
 class TypesTest extends TestCase
 {
-    public function setUp()
-    {
-        $this->types = new Types();
-    }
-
     public function testList()
     {
-        $this->assertTrue($this->types->isList(array()));
-        $this->assertTrue($this->types->isList(array(1, 'hello')));
+        $this->assertTrue(Types::isList(array()));
+        $this->assertTrue(Types::isList(array(1, 'hello')));
 
-        $this->assertFalse($this->types->isList(true));
-        $this->assertFalse($this->types->isList(array('key' => 'value')));
-        $this->assertFalse($this->types->isList(array(1 => 'first')));
-        $this->assertFalse($this->types->isList(array(1 => 'world', 0 => 'hello')));
+        $this->assertFalse(Types::isList(true));
+        $this->assertFalse(Types::isList(array('key' => 'value')));
+        $this->assertFalse(Types::isList(array(1 => 'first')));
+        $this->assertFalse(Types::isList(array(1 => 'world', 0 => 'hello')));
     }
 
     public function testMap()
     {
-        $this->assertTrue($this->types->isMap(array()));
-        $this->assertTrue($this->types->isMap(array('key' => 'value')));
-        $this->assertTrue($this->types->isMap(array(1 => 'first')));
-        $this->assertTrue($this->types->isMap(array(1 => 'world', 0 => 'hello')));
+        $this->assertTrue(Types::isMap(array()));
+        $this->assertTrue(Types::isMap(array('key' => 'value')));
+        $this->assertTrue(Types::isMap(array(1 => 'first')));
+        $this->assertTrue(Types::isMap(array(1 => 'world', 0 => 'hello')));
 
-        $this->assertFalse($this->types->isMap(true));
-        $this->assertFalse($this->types->isMap(array(1, 'hello')));
+        $this->assertFalse(Types::isMap(true));
+        $this->assertFalse(Types::isMap(array(1, 'hello')));
     }
 
     public function testTypeDateTime()
     {
-        $this->assertEquals(Types::TYPE_QDATETIME, $this->types->getTypeByValue(new \DateTime()));
+        $this->assertEquals(Types::TYPE_QDATETIME, Types::getTypeByValue(new \DateTime()));
     }
 
     /**
@@ -41,6 +36,6 @@ class TypesTest extends TestCase
      */
     public function testInvalidType()
     {
-        $this->types->getNameByType(123456);
+        Types::getNameByType(123456);
     }
 }

--- a/tests/WriterTest.php
+++ b/tests/WriterTest.php
@@ -8,7 +8,7 @@ class WriterTest extends TestCase
 {
     public function setUp()
     {
-        $this->writer = new Writer(null, array(
+        $this->writer = new Writer(array(
             'year' => function ($data, Writer $writer) {
                 $writer->writeUShort($data);
             },


### PR DESCRIPTION
The BC break mostly affects how the `Reader` and `Writer` now no longer accept a `Types` parameter.


```php
// old
$types = new Types();
$reader = new Reader($buffer, $types, $map);
$writer = new Writer($types, $map);

// new
$reader = new Reader($buffer, $map);
$writer = new Writer($map);
```

Builds on top of #22