### PR TITLE
Suggest installing ext-mbstring and use lossy conversion for QString and QChar otherwise

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,10 +85,11 @@ extensions and supports running on legacy PHP 5.3 through current PHP 7+ and
 HHVM.
 It's *highly recommended to use PHP 7+* for this project.
 
-The `QString` and `QChar` types require the `ext-mbstring` for converting
+The `QString` and `QChar` types use the `ext-mbstring` for converting
 between different character encodings.
-If this extension is missing, the respective methods will throw a
-`BadMethodCallException`.
+If this extension is missing, then special characters outside of ASCII range
+will be replaced with a `?` placeholder.
+This means that the string `hällo!` will be converted to `h?llo!` instead.
 
 ## Tests
 

--- a/README.md
+++ b/README.md
@@ -87,9 +87,11 @@ It's *highly recommended to use PHP 7+* for this project.
 
 The `QString` and `QChar` types use the `ext-mbstring` for converting
 between different character encodings.
-If this extension is missing, then special characters outside of ASCII range
-will be replaced with a `?` placeholder.
-This means that the string `hällo!` will be converted to `h?llo!` instead.
+If this extension is missing, then special characters outside of ASCII/ISO5589-1
+range will be replaced with a `?` placeholder.
+This means that the string `hällo € 10!` will be converted to `hällo ? 10!`
+instead.
+Installing `ext-mbstring` is highly recommended.
 
 ## Tests
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,16 @@ $ composer require clue/qdatastream:^0.6
 
 See also the [CHANGELOG](CHANGELOG.md) for details about version upgrades.
 
+This project aims to run on any platform and thus does not require any PHP
+extensions and supports running on legacy PHP 5.3 through current PHP 7+ and
+HHVM.
+It's *highly recommended to use PHP 7+* for this project.
+
+The `QString` and `QChar` types require the `ext-mbstring` for converting
+between different character encodings.
+If this extension is missing, the respective methods will throw a
+`BadMethodCallException`.
+
 ## Tests
 
 To run the test suite, you first need to clone this repo and then install all

--- a/composer.json
+++ b/composer.json
@@ -18,5 +18,8 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^5.0 || ^4.8"
+    },
+    "suggest": {
+        "ext-mbstring": "Required for serializing/parsing QString and QChar"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,6 @@
         "phpunit/phpunit": "^5.0 || ^4.8"
     },
     "suggest": {
-        "ext-mbstring": "Required for serializing/parsing QString and QChar"
+        "ext-mbstring": "Used for converting character encodings for QString and QChar"
     }
 }

--- a/src/Reader.php
+++ b/src/Reader.php
@@ -312,13 +312,12 @@ class Reader
             return mb_convert_encoding($str, 'UTF-8', 'UTF-16BE');
         }
 
-        // use lossy conversion which only keeps ASCII characters and uses "?" placeholder.
-        // re-assemble by removing null byte for each character and use its
-        // char code if it's ASCII (single byte) or use "?" placeholder otherwise.
-        // "hällo!" => "h?llo!"
+        // use lossy conversion which only keeps ASCII/ISO5589-1 single byte
+        // characters prefixed with null byte and use "?" placeholder otherwise.
+        // "hällo € 10!" => "hällo ? 10!"
         $out = '';
         foreach (str_split($str, 2) as $char) {
-            $out .= ($char[0] === "\x00" && $char[1] < "\x80") ? $char[1] : '?';
+            $out .= ($char[0] === "\x00") ? utf8_encode($char[1]) : '?';
         }
 
         return $out;

--- a/src/Reader.php
+++ b/src/Reader.php
@@ -22,6 +22,7 @@ class Reader
      * @return mixed|QVariant
      * @throws \UnderflowException
      * @throws \UnexpectedValueException if an unknown QUserType is encountered
+     * @throws \BadMethodCallException if a QString/QChar is encountered and ext-mbstring is missing
      */
     public function readQVariant($asNative = true)
     {
@@ -52,6 +53,7 @@ class Reader
      * @return mixed[]|QVariant[]
      * @throws \UnderflowException
      * @throws \UnexpectedValueException if an unknown QUserType is encountered
+     * @throws \BadMethodCallException if a QString/QChar is encountered and ext-mbstring is missing
      */
     public function readQVariantList($asNative = true)
     {
@@ -70,6 +72,7 @@ class Reader
      * @return mixed[]|QVariant[]
      * @throws \UnderflowException
      * @throws \UnexpectedValueException if an unknown QUserType is encountered
+     * @throws \BadMethodCallException if ext-mbstring is missing
      */
     public function readQVariantMap($asNative = true)
     {
@@ -89,12 +92,13 @@ class Reader
     /**
      * @return string|null text string in UTF-8 encoding
      * @throws \UnderflowException
+     * @throws \BadMethodCallException if ext-mbstring is missing
      * @see self::readQByteArray() for reading binary data
      */
     public function readQString()
     {
         $str = $this->readQByteArray();
-        if ($str !== null) {
+        if ($str !== null && $str !== '') {
             $str = $this->conv($str);
         }
 
@@ -104,6 +108,7 @@ class Reader
     /**
      * @return string single text character in UTF-8 encoding
      * @throws \UnderflowException
+     * @throws \BadMethodCallException if ext-mbstring is missing
      */
     public function readQChar()
     {
@@ -113,6 +118,7 @@ class Reader
     /**
      * @return string[] array of text strings in UTF-8 encoding
      * @throws \UnderflowException
+     * @throws \BadMethodCallException if ext-mbstring is missing
      */
     public function readQStringList()
     {
@@ -221,6 +227,7 @@ class Reader
      * @param bool $asNative
      * @return mixed|QVariant
      * @throws \UnexpectedValueException if an unknown QUserType is encountered
+     * @throws \BadMethodCallException if a QString/QChar is encountered and ext-mbstring is missing
      */
     public function readQUserType($asNative = true)
     {
@@ -240,6 +247,7 @@ class Reader
      * @param string $name
      * @return mixed
      * @throws \UnexpectedValueException if an unknown QUserType is encountered
+     * @throws \BadMethodCallException if a QString/QChar is encountered and ext-mbstring is missing
      */
     public function readQUserTypeByName($name)
     {
@@ -300,6 +308,10 @@ class Reader
 
     private function conv($str)
     {
+        if (!function_exists('mb_convert_encoding')) {
+            throw new \BadMethodCallException('Missing function (ext-mbstring not loaded?)'); // @codeCoverageIgnore
+        }
+
         // transcode UTF-16 (big endian) to UTF-8
         return mb_convert_encoding($str, 'UTF-8', 'UTF-16BE');
     }

--- a/src/Writer.php
+++ b/src/Writer.php
@@ -301,20 +301,10 @@ class Writer
             return mb_convert_encoding($str, 'UTF-16BE', 'UTF-8');
         }
 
-        // otherwise match all unicode chars
-        $matches = array();
-        preg_match_all('/./us', $str, $matches);
-
-        // use lossy conversion which only keeps ASCII characters and uses "?" placeholder.
-        // re-assemble by prefixing null byte for each character and use its
-        // char code if it's ASCII (single byte) or use "?" placeholder otherwise.
-        // "hällo!" => "h?llo!"
-        $str = '';
-        foreach ($matches[0] as $char) {
-            $str .= "\x00" . (isset($char[1]) ? '?' : $char);
-        }
-
-        return $str;
+        // use lossy conversion which only keeps ASCII/ISO8859-1 single byte
+        // characters prefixed with null byte and use "?" placeholder otherwise.
+        // "hällo € 10!" => "hällo ? 10!"
+        return "\x00" . implode("\x00", str_split(utf8_decode($str)));
     }
 
     private function writeBE($bytes)

--- a/src/Writer.php
+++ b/src/Writer.php
@@ -85,6 +85,7 @@ class Writer
     /**
      * @param string[] $strings array of text strings in UTF-8 encoding
      * @return void
+     * @throws \BadMethodCallException if ext-mbstring is missing
      */
     public function writeQStringList(array $strings)
     {
@@ -99,10 +100,11 @@ class Writer
      * @param string|null $str text string in UTF-8 encoding
      * @return void
      * @see self::writeQByteArray() for writing binary data
+     * @throws \BadMethodCallException if ext-mbstring is missing
      */
     public function writeQString($str)
     {
-        if ($str !== null) {
+        if ($str !== null && $str !== '') {
             $str = $this->conv($str);
         }
 
@@ -112,6 +114,7 @@ class Writer
     /**
      * @param string $char single text character in UTF-8 encoding
      * @return void
+     * @throws \BadMethodCallException if ext-mbstring is missing
      */
     public function writeQChar($char)
     {
@@ -147,6 +150,7 @@ class Writer
      * @param QVariant|mixed $value
      * @return void
      * @throws \UnexpectedValueException if an unknown QUserType is encountered
+     * @throws \BadMethodCallException if a QString/QChar is encountered and ext-mbstring is missing
      */
     public function writeQVariant($value)
     {
@@ -183,6 +187,7 @@ class Writer
      * @param string $userType
      * @return void
      * @throws \UnexpectedValueException if an unknown QUserType is encountered
+     * @throws \BadMethodCallException if a QString/QChar is encountered and ext-mbstring is missing
      */
     public function writeQUserTypeByName($value, $userType)
     {
@@ -199,6 +204,7 @@ class Writer
      * @param array<QVariant|mixed> $list
      * @return void
      * @throws \UnexpectedValueException if an unknown QUserType is encountered
+     * @throws \BadMethodCallException if a QString/QChar is encountered and ext-mbstring is missing
      */
     public function writeQVariantList(array $list)
     {
@@ -213,6 +219,7 @@ class Writer
      * @param array $map
      * @return void
      * @throws \UnexpectedValueException if an unknown QUserType is encountered
+     * @throws \BadMethodCallException if ext-mbstring is missing
      */
     public function writeQVariantMap(array $map)
     {
@@ -289,6 +296,10 @@ class Writer
 
     private function conv($str)
     {
+        if (!function_exists('mb_convert_encoding')) {
+            throw new \BadMethodCallException('Missing function (ext-mbstring not loaded?)'); // @codeCoverageIgnore
+        }
+
         // transcode UTF-8 to UTF-16 (big endian)
         return mb_convert_encoding($str, 'UTF-16BE', 'UTF-8');
     }

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -20,12 +20,25 @@ class FunctionalTest extends TestCase
         $this->assertEquals($in, $reader->readQString());
     }
 
+    public function testQStringUnicodeSimple()
+    {
+        $in = 'hellö';
+
+        $writer = new Writer();
+        $writer->writeQString($in);
+
+        $data = (string)$writer;
+        $reader = new Reader($data);
+
+        $this->assertEquals($in, $reader->readQString());
+    }
+
     /**
      * @requires extension mbstring
      */
-    public function testQStringUnicode()
+    public function testQStringUnicodeOutsideLatin1RequiresExtMbstring()
     {
-        $in = 'hellö';
+        $in = 'hellö € 10';
 
         $writer = new Writer();
         $writer->writeQString($in);
@@ -114,9 +127,6 @@ class FunctionalTest extends TestCase
         $this->assertEquals($in, $reader->readQVariant());
     }
 
-    /**
-     * @requires extension mbstring
-     */
     public function testQVariantExplicitQCharType()
     {
         $in = 'ö';
@@ -211,9 +221,6 @@ class FunctionalTest extends TestCase
         $this->assertEquals(array('hello', 'world'), $reader->readQStringList());
     }
 
-    /**
-     * @requires extension mbstring
-     */
     public function testQCharMultipleUnicode()
     {
         $writer = new Writer();

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -7,10 +7,23 @@ use Clue\QDataStream\QVariant;
 
 class FunctionalTest extends TestCase
 {
+    public function testQString()
+    {
+        $in = 'hello';
+
+        $writer = new Writer();
+        $writer->writeQString($in);
+
+        $data = (string)$writer;
+        $reader = new Reader($data);
+
+        $this->assertEquals($in, $reader->readQString());
+    }
+
     /**
      * @requires extension mbstring
      */
-    public function testQString()
+    public function testQStringUnicode()
     {
         $in = 'hellö';
 
@@ -45,9 +58,6 @@ class FunctionalTest extends TestCase
         $this->assertEquals(null, $reader->readQString());
     }
 
-    /**
-     * @requires extension mbstring
-     */
     public function testQVariantAutoTypes()
     {
         $in = array(
@@ -74,7 +84,6 @@ class FunctionalTest extends TestCase
     /**
      * @depends testQVariantAutoTypes
      * @param Reader $reader
-     * @requires extension mbstring
      */
     public function testQVariantAutoTypeAsQVariant(Reader $reader)
     {
@@ -143,9 +152,6 @@ class FunctionalTest extends TestCase
         $this->assertEquals($expected, $reader->readQVariantList());
     }
 
-    /**
-     * @requires extension mbstring
-     */
     public function testQVariantMapSomeExplicit()
     {
         $in = array(
@@ -166,9 +172,6 @@ class FunctionalTest extends TestCase
         $this->assertEquals($expected, $reader->readQVariantMap());
     }
 
-    /**
-     * @requires extension mbstring
-     */
     public function testQUserType()
     {
         $in = array(
@@ -197,9 +200,6 @@ class FunctionalTest extends TestCase
         $this->assertEquals($in, $reader->readQVariant());
     }
 
-    /**
-     * @requires extension mbstring
-     */
     public function testQStringList()
     {
         $writer = new Writer();
@@ -214,7 +214,7 @@ class FunctionalTest extends TestCase
     /**
      * @requires extension mbstring
      */
-    public function testQCharMultiple()
+    public function testQCharMultipleUnicode()
     {
         $writer = new Writer();
         $writer->writeQChar('a');

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -7,6 +7,9 @@ use Clue\QDataStream\QVariant;
 
 class FunctionalTest extends TestCase
 {
+    /**
+     * @requires extension mbstring
+     */
     public function testQString()
     {
         $in = 'hellö';
@@ -42,6 +45,9 @@ class FunctionalTest extends TestCase
         $this->assertEquals(null, $reader->readQString());
     }
 
+    /**
+     * @requires extension mbstring
+     */
     public function testQVariantAutoTypes()
     {
         $in = array(
@@ -68,6 +74,7 @@ class FunctionalTest extends TestCase
     /**
      * @depends testQVariantAutoTypes
      * @param Reader $reader
+     * @requires extension mbstring
      */
     public function testQVariantAutoTypeAsQVariant(Reader $reader)
     {
@@ -98,6 +105,9 @@ class FunctionalTest extends TestCase
         $this->assertEquals($in, $reader->readQVariant());
     }
 
+    /**
+     * @requires extension mbstring
+     */
     public function testQVariantExplicitQCharType()
     {
         $in = 'ö';
@@ -133,6 +143,9 @@ class FunctionalTest extends TestCase
         $this->assertEquals($expected, $reader->readQVariantList());
     }
 
+    /**
+     * @requires extension mbstring
+     */
     public function testQVariantMapSomeExplicit()
     {
         $in = array(
@@ -153,6 +166,9 @@ class FunctionalTest extends TestCase
         $this->assertEquals($expected, $reader->readQVariantMap());
     }
 
+    /**
+     * @requires extension mbstring
+     */
     public function testQUserType()
     {
         $in = array(
@@ -181,6 +197,9 @@ class FunctionalTest extends TestCase
         $this->assertEquals($in, $reader->readQVariant());
     }
 
+    /**
+     * @requires extension mbstring
+     */
     public function testQStringList()
     {
         $writer = new Writer();
@@ -190,10 +209,11 @@ class FunctionalTest extends TestCase
         $reader = new Reader($data);
 
         $this->assertEquals(array('hello', 'world'), $reader->readQStringList());
-
-        return new Reader($data);
     }
 
+    /**
+     * @requires extension mbstring
+     */
     public function testQCharMultiple()
     {
         $writer = new Writer();

--- a/tests/WriterTest.php
+++ b/tests/WriterTest.php
@@ -73,9 +73,6 @@ class WriterTest extends TestCase
         $this->assertEquals("\xFF\xFF\xFF\xFF", (string)$this->writer);
     }
 
-    /**
-     * @requires extension mbstring
-     */
     public function testQStringHi()
     {
         $this->writer->writeQString('Hi');
@@ -149,9 +146,6 @@ class WriterTest extends TestCase
         $this->assertEquals("\x00\x00\x00\x0A\x00" . "\x00\x00\x00\x00", (string)$this->writer);
     }
 
-    /**
-     * @requires extension mbstring
-     */
     public function testQVariantStringHi()
     {
         $this->writer->writeQVariant('Hi');
@@ -198,9 +192,6 @@ class WriterTest extends TestCase
         $this->assertEquals("\x00\x00\x00\x7F" . "\x00" . "\x00\x00\x00\x05" . "year\x00" . "\x07\xDF", (string)$this->writer);
     }
 
-    /**
-     * @requires extension mbstring
-     */
     public function testQUserTypeComplex()
     {
         $user = array(

--- a/tests/WriterTest.php
+++ b/tests/WriterTest.php
@@ -73,6 +73,9 @@ class WriterTest extends TestCase
         $this->assertEquals("\xFF\xFF\xFF\xFF", (string)$this->writer);
     }
 
+    /**
+     * @requires extension mbstring
+     */
     public function testQStringHi()
     {
         $this->writer->writeQString('Hi');
@@ -146,6 +149,9 @@ class WriterTest extends TestCase
         $this->assertEquals("\x00\x00\x00\x0A\x00" . "\x00\x00\x00\x00", (string)$this->writer);
     }
 
+    /**
+     * @requires extension mbstring
+     */
     public function testQVariantStringHi()
     {
         $this->writer->writeQVariant('Hi');
@@ -192,6 +198,9 @@ class WriterTest extends TestCase
         $this->assertEquals("\x00\x00\x00\x7F" . "\x00" . "\x00\x00\x00\x05" . "year\x00" . "\x07\xDF", (string)$this->writer);
     }
 
+    /**
+     * @requires extension mbstring
+     */
     public function testQUserTypeComplex()
     {
         $user = array(


### PR DESCRIPTION
The `QString` and `QChar` types use the `ext-mbstring` for converting between different character encodings. If this extension is missing, then special characters outside of ASCII/ISO5589-1 range will be replaced with a `?` placeholder. This means that the string `hällo € 10!` will be converted to `hällo ? 10!` instead. Installing `ext-mbstring` is highly recommended.

Builds on top of #22