### PR TITLE
Transcode between UTF-8 and UTF-16BE also if ext-mbstring is not available

### DIFF
--- a/tests/ReaderTest.php
+++ b/tests/ReaderTest.php
@@ -128,4 +128,28 @@ class ReaderTest extends TestCase
         $reader = new Reader($in);
         $this->assertEquals('€', $reader->readQChar());
     }
+
+    public function testQStringWideEuro()
+    {
+        $in = "\x00\x00\x00\x02" . "\x20\xAC";
+
+        $reader = new Reader($in);
+        $this->assertEquals('€', $reader->readQString());
+    }
+
+    public function testQStringWideSupplementaryPlane()
+    {
+        $in = "\x00\x00\x00\x04" . "\xd8\x00\xdf\x48";
+
+        $reader = new Reader($in);
+        $this->assertEquals('𐍈', $reader->readQString());
+    }
+
+    public function testQStringWideViolin()
+    {
+        $in = "\x00\x00\x00\x04" . "\xD8\x34\xDD\x1E";
+
+        $reader = new Reader($in);
+        $this->assertEquals('𝄞', $reader->readQString());
+    }
 }

--- a/tests/WriterTest.php
+++ b/tests/WriterTest.php
@@ -110,6 +110,24 @@ class WriterTest extends TestCase
         $this->assertEquals("\x00?", (string)$this->writer);
     }
 
+    public function testQStringWideEuro()
+    {
+        $this->writer->writeQString('€');
+        $this->assertEquals("\x00\x00\x00\x02" . "\x20\xAC", (string)$this->writer);
+    }
+
+    public function testQStringWideSupplementaryPlane()
+    {
+        $this->writer->writeQString("\xF0\x90\x8D\x88"); // 𐍈
+        $this->assertEquals("\x00\x00\x00\x04" . "\xd8\x00\xdf\x48", (string)$this->writer);
+    }
+
+    public function testQStringWideViolin()
+    {
+        $this->writer->writeQString("𝄞");
+        $this->assertEquals("\x00\x00\x00\x04" . "\xD8\x34\xDD\x1E", (string)$this->writer);
+    }
+
     public function testQTimeExactlyMidnightIsNullMilliseconds()
     {
         date_default_timezone_set('UTC');


### PR DESCRIPTION
The `QString` and `QChar` types use the `ext-mbstring` for converting between different character encodings. If this extension is missing, then this library will now use a slighty slower Regex work-around that should otherwise work equally well. Installing `ext-mbstring` is highly recommended.

Unlike the previous implementation in #28, this now supports the full Unicode range which also includes characters outside of BMP, such as emojis.