### PR TITLE
Fix transcoding strings with newlines between UTF-8 and UTF-16BE when ext-mbstring is not available

### DIFF
--- a/src/Reader.php
+++ b/src/Reader.php
@@ -328,7 +328,7 @@ class Reader
 
         // Otherwise convert each byte pair to its Unicode code point and
         // then manually encode as UTF-8 bytes.
-        return preg_replace_callback('/(?:[\xD8-\xDB]...)|(?:..)/', function ($m) {
+        return preg_replace_callback('/(?:[\xD8-\xDB]...)|(?:..)/s', function ($m) {
             if (isset($m[0][3])) {
                 // U+10000 - U+10FFFF uses four UTF-16 bytes and 4 UTF-8 bytes
                 // get code point from higher and lower surrogate and convert

--- a/src/Writer.php
+++ b/src/Writer.php
@@ -308,7 +308,7 @@ class Writer
 
         // otherwise match each UTF-8 character byte sequence, manually convert
         // it to its Unicode code point and then encode as UTF-16BE byte sequence.
-        return preg_replace_callback('/./u', function ($m) {
+        return preg_replace_callback('/./su', function ($m) {
             if (!isset($m[0][1])) {
                 // U+0000 - U+007F single byte ASCII/UTF-8 character
                 return "\x00" . $m[0];

--- a/tests/ReaderTest.php
+++ b/tests/ReaderTest.php
@@ -129,6 +129,14 @@ class ReaderTest extends TestCase
         $this->assertEquals('€', $reader->readQChar());
     }
 
+    public function testQStringWithNewline()
+    {
+        $in = "\x00\x00\x00\x06" . "\x00a\x00\n\00b";
+
+        $reader = new Reader($in);
+        $this->assertEquals("a\nb", $reader->readQString());
+    }
+
     public function testQStringWideEuro()
     {
         $in = "\x00\x00\x00\x02" . "\x20\xAC";

--- a/tests/WriterTest.php
+++ b/tests/WriterTest.php
@@ -80,6 +80,12 @@ class WriterTest extends TestCase
         $this->assertEquals("\x00\x00\x00\x04" . "\x00H\x00i", (string)$this->writer);
     }
 
+    public function testQStringWithNewline()
+    {
+        $this->writer->writeQString("a\nb");
+        $this->assertEquals("\x00\x00\x00\x06" . "\x00a\x00\n\x00b", (string)$this->writer);
+    }
+
     public function testQCharAscii()
     {
         $this->writer->writeQChar('o');


### PR DESCRIPTION
Builds on top of #30