### PR TITLE
 Always return QVariantMap as instance of stdClass instead of assoc array

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ This works similar to JSON encoding and accepts primitive values of type `int`,
 
 ```php
 $rows = [
-    [
+    (object)[
         'id' => 10,
         'name' => 'Alice',
         'active' => true,
@@ -97,25 +97,14 @@ $reader = new Reader($data);
 $values = $reader->readQVariant();
 
 assert(count($values) === 1);
-assert($values[0]['id'] === 10);
-assert($values[0]['groups'][0] === 'admin');
-```
-
-Note that associative arrays and `stdClass` objects be will serialized as a "map",
-while vector arrays will be serialized as a "list". By default, the
-`readQVariant()` method will unserialize both to a PHP array. This means that both
-an empty "map" and an emtpy "list" will be represented as an empty PHP array.
-This may be a problem for some use cases, so the `Reader` class accepts an
-optional boolean flag to always unserialize type "map" to a `stdClass`:
-
-```php
-$reader = new Reader($data, array(), true);
-$values = $reader->readQVariant();
-
-assert(count($values) === 1);
 assert($values[0]->id === 10);
 assert($values[0]->groups[0] === 'admin');
 ```
+
+Note that associative arrays and `stdClass` objects be will serialized as a "map",
+while vector arrays will be serialized as a "list". In order to avoid confusion
+between these similar data structures, using instances of `stdClass` is considered
+the preferred method in this project.
 
 See the [class outline](src/QVariant.php) for more details.
 

--- a/src/Reader.php
+++ b/src/Reader.php
@@ -9,14 +9,17 @@ class Reader
 
     private $userTypeMap;
     private $hasNull = true;
+    private $mapAsObject;
+
     /**
      * @param string $buffer
      * @param array  $userTypeMap
      */
-    public function __construct($buffer, $userTypeMap = array())
+    public function __construct($buffer, $userTypeMap = array(), $mapAsObjects = false)
     {
         $this->buffer = $buffer;
         $this->userTypeMap = $userTypeMap;
+        $this->mapAsObject = $mapAsObjects;
     }
 
     /**
@@ -69,7 +72,7 @@ class Reader
 
     /**
      * @param bool $asNative
-     * @return mixed[]|QVariant[]
+     * @return mixed[]|QVariant[]|\stdClass
      * @throws \UnderflowException
      * @throws \UnexpectedValueException if an unknown QUserType is encountered
      */
@@ -83,6 +86,9 @@ class Reader
             $value = $this->readQVariant($asNative);
 
             $map[$key] = $value;
+        }
+        if ($this->mapAsObject) {
+            return (object)$map;
         }
 
         return $map;

--- a/src/Reader.php
+++ b/src/Reader.php
@@ -9,17 +9,15 @@ class Reader
 
     private $userTypeMap;
     private $hasNull = true;
-    private $mapAsObject;
 
     /**
      * @param string $buffer
      * @param array  $userTypeMap
      */
-    public function __construct($buffer, $userTypeMap = array(), $mapAsObjects = false)
+    public function __construct($buffer, $userTypeMap = array())
     {
         $this->buffer = $buffer;
         $this->userTypeMap = $userTypeMap;
-        $this->mapAsObject = $mapAsObjects;
     }
 
     /**
@@ -72,7 +70,7 @@ class Reader
 
     /**
      * @param bool $asNative
-     * @return mixed[]|QVariant[]|\stdClass
+     * @return \stdClass
      * @throws \UnderflowException
      * @throws \UnexpectedValueException if an unknown QUserType is encountered
      */
@@ -80,15 +78,12 @@ class Reader
     {
         $length = $this->readUInt();
 
-        $map = array();
+        $map = new \stdClass();
         for ($i = 0; $i < $length; ++$i) {
             $key = $this->readQString();
             $value = $this->readQVariant($asNative);
 
-            $map[$key] = $value;
-        }
-        if ($this->mapAsObject) {
-            return (object)$map;
+            $map->$key = $value;
         }
 
         return $map;

--- a/src/Types.php
+++ b/src/Types.php
@@ -107,15 +107,17 @@ final class Types
     }
 
     /**
-     * Checks whether the given argument is a map (hash map / assoc array)
+     * Checks whether the given argument is a map (hash map / assoc array or stdClass)
      *
      * An empty array is considered both a list and a map.
      *
-     * @param array $array
-     * @return boolean
+     * An empty stdClass is considered a map.
+     *
+     * @param mixed $value
+     * @return bool
      */
-    public static function isMap($array)
+    public static function isMap($value)
     {
-        return ($array === array() || (is_array($array) && !self::isList($array)));
+        return ($value === array() || (is_array($value) && !self::isList($value)) || $value instanceof \stdClass);
     }
 }

--- a/src/Writer.php
+++ b/src/Writer.php
@@ -214,12 +214,16 @@ class Writer
     }
 
     /**
-     * @param array $map
+     * @param array|\stdClass $map
      * @return void
      * @throws \UnexpectedValueException if an unknown QUserType is encountered
      */
-    public function writeQVariantMap(array $map)
+    public function writeQVariantMap($map)
     {
+        if ($map instanceof \stdClass) {
+            $map = (array)$map;
+        }
+
         $this->writeUInt(count($map));
 
         foreach ($map as $key => $value) {

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -121,6 +121,27 @@ class FunctionalTest extends TestCase
         );
     }
 
+    public function testQVariantAutoTypesAcceptsStdClassObjects()
+    {
+        $in = (object)array(
+            'hello' => 'world',
+            'bool' => true,
+            'year' => 2015,
+            'list' => array(
+                'first',
+                'second'
+            )
+        );
+
+        $writer = new Writer();
+        $writer->writeQVariant($in);
+
+        $data = (string)$writer;
+        $reader = new Reader($data, array(), true);
+
+        $this->assertEquals($in, $reader->readQVariant());
+    }
+
     public function testQVariantExplicitCharType()
     {
         $in = 100;

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -80,7 +80,7 @@ class FunctionalTest extends TestCase
 
     public function testQVariantAutoTypes()
     {
-        $in = array(
+        $in = (object)array(
             'hello' => 'world',
             'bool' => true,
             'year' => 2015,
@@ -108,7 +108,7 @@ class FunctionalTest extends TestCase
     public function testQVariantAutoTypeAsQVariant(Reader $reader)
     {
         $this->assertEquals(
-            new QVariant(array(
+            new QVariant((object)array(
                 'hello' => new QVariant('world', Types::TYPE_QSTRING),
                 'bool' => new QVariant(true, Types::TYPE_BOOL),
                 'year' => new QVariant(2015, Types::TYPE_INT),
@@ -121,9 +121,9 @@ class FunctionalTest extends TestCase
         );
     }
 
-    public function testQVariantAutoTypesAcceptsStdClassObjects()
+    public function testQVariantAutoTypesEncodesAssocArrayAsMapAndListAsList()
     {
-        $in = (object)array(
+        $in = array(
             'hello' => 'world',
             'bool' => true,
             'year' => 2015,
@@ -137,9 +137,9 @@ class FunctionalTest extends TestCase
         $writer->writeQVariant($in);
 
         $data = (string)$writer;
-        $reader = new Reader($data, array(), true);
+        $reader = new Reader($data);
 
-        $this->assertEquals($in, $reader->readQVariant());
+        $this->assertEquals($in, (array)$reader->readQVariant());
     }
 
     public function testQVariantExplicitCharType()
@@ -192,11 +192,11 @@ class FunctionalTest extends TestCase
 
     public function testQVariantMapSomeExplicit()
     {
-        $in = array(
+        $in = (object)array(
             'id' => new QVariant(62000, Types::TYPE_USHORT),
             'name' => 'test'
         );
-        $expected = array(
+        $expected = (object)array(
             'id' => 62000,
             'name' => 'test'
         );


### PR DESCRIPTION
The `readQVariantMap()` method now returns an insance of `stdClass` instead of an associative array.

Note that associative arrays and `stdClass` objects be will serialized as a "map",
while vector arrays will be serialized as a "list". In order to avoid confusion
between these similar data structures, using instances of `stdClass` is considered
the preferred method in this project.