### PR TITLE
Improve performance by avoiding unnecessary methods calls and extension checks during runtime

### DIFF
--- a/src/Reader.php
+++ b/src/Reader.php
@@ -9,6 +9,7 @@ class Reader
 
     private $userTypeMap;
     private $hasNull = true;
+    private $supportsExtMbstring;
 
     /**
      * @param string $buffer
@@ -18,6 +19,9 @@ class Reader
     {
         $this->buffer = $buffer;
         $this->userTypeMap = $userTypeMap;
+
+        // prefer mb_convert_encoding if available
+        $this->supportsExtMbstring = \function_exists('mb_convert_encoding');
     }
 
     /**
@@ -372,12 +376,11 @@ class Reader
      *
      * @param string $str
      * @return string
-     * @codeCoverageIgnore
      */
     private function conv($str)
     {
         // prefer mb_convert_encoding if available
-        if (function_exists('mb_convert_encoding')) {
+        if ($this->supportsExtMbstring) {
             return mb_convert_encoding($str, 'UTF-8', 'UTF-16BE');
         }
 

--- a/src/Reader.php
+++ b/src/Reader.php
@@ -32,15 +32,62 @@ class Reader
         $type = $this->readUInt();
 
         if ($this->hasNull) {
-            /*$isNull = */ $this->readBool();
+            // $isNull = $this->readBool();
+            $this->pos++;
         }
 
-        $name = 'read' . Types::getNameByType($type);
-        if (!method_exists($this, $name)) {
-            throw new \BadMethodCallException('Known variant type (' . $type . '), but has no "' . $name . '()" method'); // @codeCoverageIgnore
+        switch ($type) {
+            case Types::TYPE_BOOL:
+                $value = $this->readBool();
+                break;
+            case Types::TYPE_INT:
+                $value = $this->readInt();
+                break;
+            case Types::TYPE_UINT:
+                $value = $this->readUInt();
+                break;
+            case Types::TYPE_QCHAR:
+                $value = $this->readQChar();
+                break;
+            case Types::TYPE_QVARIANT_MAP:
+                $value = $this->readQVariantMap($asNative);
+                break;
+            case Types::TYPE_QVARIANT_LIST:
+                $value = $this->readQVariantList($asNative);
+                break;
+            case Types::TYPE_QSTRING:
+                $value = $this->readQString();
+                break;
+            case Types::TYPE_QSTRING_LIST:
+                $value = $this->readQStringList();
+                break;
+            case Types::TYPE_QBYTE_ARRAY:
+                $value = $this->readQByteArray();
+                break;
+            case Types::TYPE_QTIME:
+                $value = $this->readQTime();
+                break;
+            case Types::TYPE_QDATETIME:
+                $value = $this->readQDateTime();
+                break;
+            case Types::TYPE_QUSER_TYPE:
+                $value = $this->readQUserType($asNative);
+                break;
+            case Types::TYPE_SHORT:
+                $value = $this->readShort();
+                break;
+            case Types::TYPE_CHAR:
+                $value = $this->readChar();
+                break;
+            case Types::TYPE_USHORT:
+                $value = $this->readUShort();
+                break;
+            case Types::TYPE_UCHAR:
+                $value = $this->readUChar();
+                break;
+            default:
+                throw new \UnexpectedValueException('Invalid/unknown variant type (' . $type . ')');
         }
-
-        $value = $this->$name($asNative);
 
         // wrap in QVariant if requested and this is not a UserType
         if (!$asNative && $type !== Types::TYPE_QUSER_TYPE) {
@@ -229,7 +276,14 @@ class Reader
      */
     public function readBool()
     {
-        return $this->read(1) !== "\x00" ? true : false;
+        // this method is used all over this class, so it deserves a special
+        // case for reading common case of 1 byte without an expensive substr()
+        // function call. Otherwise identical with parsing result of `read(1)`.
+        if (!isset($this->buffer[$this->pos])) {
+            throw new \UnderflowException('Not enough data in buffer');
+        }
+
+        return $this->buffer[$this->pos++] !== "\x00";
     }
 
     /**

--- a/src/Writer.php
+++ b/src/Writer.php
@@ -9,6 +9,7 @@ class Writer
     private $hasNull = true;
 
     private $buffer = '';
+    private $supportsExtMbstring;
 
     /**
      * @param array $userTypeMap
@@ -16,6 +17,9 @@ class Writer
     public function __construct($userTypeMap = array())
     {
         $this->userTypeMap = $userTypeMap;
+
+        // prefer mb_convert_encoding if available
+        $this->supportsExtMbstring = \function_exists('mb_convert_encoding');
     }
 
     /**
@@ -300,13 +304,11 @@ class Writer
      *
      * @param string $str
      * @return string
-     * @codeCoverageIgnore
      */
     private function conv($str)
     {
         // prefer mb_convert_encoding if available
-        if (function_exists('mb_convert_encoding')) {
-            mb_substitute_character(ord('?'));
+        if ($this->supportsExtMbstring) {
             return mb_convert_encoding($str, 'UTF-16BE', 'UTF-8');
         }
 

--- a/tests/ReaderTest.php
+++ b/tests/ReaderTest.php
@@ -55,6 +55,20 @@ class ReaderTest extends TestCase
         $this->assertEquals('Europe/Berlin', $value->getTimezone()->getName());
     }
 
+    public function testReadQVariantWithNullQTimeIsExactlyMidnight()
+    {
+        date_default_timezone_set('UTC');
+
+        $midnight = new DateTime('midnight');
+
+        $in = "\x00\x00\x00\x0f" . "\x00" . "\x00\x00\x00\x00";
+        $reader = new Reader($in);
+
+        $value = $reader->readQVariant();
+
+        $this->assertEquals($midnight, $value);
+    }
+
     /**
      * @depends testUserTypeMapping
      * @param Reader $reader
@@ -89,12 +103,42 @@ class ReaderTest extends TestCase
     /**
      * @expectedException UnexpectedValueException
      */
+    public function testQVariantTypeUnknown()
+    {
+        $in = "\x00\x00\x00\x00" . "\x00";
+
+        $reader = new Reader($in);
+        $reader->readQVariant();
+    }
+
+    /**
+     * @expectedException UnexpectedValueException
+     */
     public function testQUserTypeUnknown()
     {
         $in = "\x00\x00\x00\x7F" . "\x00" . "\x00\x00\x00\x05" . "demo\x00" . "\x00\x00\x00\xFF";
 
         $reader = new Reader($in);
         $reader->readQVariant();
+    }
+
+    public function testBool()
+    {
+        $in = "\x00";
+
+        $reader = new Reader($in);
+        $this->assertFalse($reader->readBool());
+    }
+
+    /**
+     * @expectedException UnderflowException
+     */
+    public function testBoolBeyondLimitThrows()
+    {
+        $in = "";
+
+        $reader = new Reader($in);
+        $this->assertFalse($reader->readBool());
     }
 
     public function testQCharAscii()


### PR DESCRIPTION
This PR improves parsing performance by around ~25% for common use cases (see also provided benchmark example). Is does so by avoiding unnecessary methods calls and extension checks during runtime and does not otherwise affect any of the existing logic.

Builds on top of #26