### PR TITLE
Run tests on PHP 7.4 and PHPUnit 9, update PHPUnit configuration schema for PHPUnit 9.3 and support PHP 8

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/examples/ export-ignore
+/phpunit.xml.dist export-ignore
+/phpunit.xml.legacy export-ignore
+/tests/ export-ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ jobs:
     strategy:
       matrix:
         php:
+          - 8.0
           - 7.4
           - 7.3
           - 7.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,8 @@ jobs:
     strategy:
       matrix:
         php:
+          - 7.4
+          - 7.3
           - 7.2
           - 7.1
           - 7.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,4 +27,7 @@ jobs:
           php-version: ${{ matrix.php }}
       - run: composer install
       - run: vendor/bin/phpunit --coverage-text
+        if: matrix.php >= 7.3
+      - run: vendor/bin/phpunit --coverage-text -c phpunit.xml.legacy
+        if: matrix.php < 7.3
       - run: php examples/benchmark.php

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ $ composer require clue/qdatastream:^0.8
 See also the [CHANGELOG](CHANGELOG.md) for details about version upgrades.
 
 This project aims to run on any platform and thus does not require any PHP
-extensions and supports running on legacy PHP 5.3 through current PHP 7+.
+extensions and supports running on legacy PHP 5.3 through current PHP 8+.
 It's *highly recommended to use PHP 7+* for this project.
 
 The `QString` and `QChar` types use the `ext-mbstring` for converting

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "php": ">=5.3"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.0 || ^5.7 || ^4.8.35"
+        "phpunit/phpunit": "^9.3 || ^5.7 || ^4.8.35"
     },
     "suggest": {
         "ext-mbstring": "Used for converting character encodings for QString and QChar"

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "php": ">=5.3"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.0 || ^5.7 || ^4.8.35"
+        "phpunit/phpunit": "^9.0 || ^5.7 || ^4.8.35"
     },
     "suggest": {
         "ext-mbstring": "Used for converting character encodings for QString and QChar"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<phpunit bootstrap="vendor/autoload.php"
+<!-- PHPUnit configuration file with new format for PHPUnit 9.3+ -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
          colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
->
+         cacheResult="false">
     <testsuites>
         <testsuite name="QDataStream Test Suite">
             <directory>./tests/</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist>
+    <coverage>
+        <include>
             <directory>./src/</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </coverage>
 </phpunit>

--- a/phpunit.xml.legacy
+++ b/phpunit.xml.legacy
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- PHPUnit configuration file with old format for PHPUnit 9.2 or older -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/4.8/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true">
+    <testsuites>
+        <testsuite name="QDataStream Test Suite">
+            <directory>./tests/</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist>
+            <directory>./src/</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -299,7 +299,7 @@ class FunctionalTest extends TestCase
         $reader = new Reader($in);
 
         $dt = $reader->readQTime();
-        $this->assertLessThan(1000, $now->diff($dt)->format('u'));
+        $this->assertLessThan(1000, $now->diff($dt)->format('%u'));
     }
 
     public function testReadQTimeNowCorrectTimezone()
@@ -316,7 +316,7 @@ class FunctionalTest extends TestCase
 
         $dt = $reader->readQTime();
 
-        $this->assertLessThan(1000, $now->diff($dt)->format('u'));
+        $this->assertLessThan(1000, $now->diff($dt)->format('%u'));
         $this->assertEquals('Europe/Berlin', $dt->getTimezone()->getName());
     }
 
@@ -383,7 +383,7 @@ class FunctionalTest extends TestCase
         $reader = new Reader($in);
 
         $dt = $reader->readQDateTime();
-        $this->assertLessThan(1000, $now->diff($dt)->format('u'));
+        $this->assertLessThan(1000, $now->diff($dt)->format('%u'));
     }
 
     public function testReadQVariantWithQDateTimeNow()
@@ -399,7 +399,7 @@ class FunctionalTest extends TestCase
         $reader = new Reader($in);
 
         $dt = $reader->readQVariant();
-        $this->assertLessThan(1000, $now->diff($dt)->format('u'));
+        $this->assertLessThan(1000, $now->diff($dt)->format('%u'));
     }
 
     public function testReadQDateTimeNowWithCorrectTimezone()
@@ -415,7 +415,7 @@ class FunctionalTest extends TestCase
         $reader = new Reader($in);
 
         $dt = $reader->readQDateTime();
-        $this->assertLessThan(1000, $now->diff($dt)->format('u'));
+        $this->assertLessThan(1000, $now->diff($dt)->format('%u'));
 
         $this->assertEquals('Europe/Berlin', $dt->getTimezone()->getName());
     }

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -367,7 +367,7 @@ class FunctionalTest extends TestCase
         $reader = new Reader($in);
 
         $dt = $reader->readQTime();
-        $this->assertEquals($now, $dt->format('U.u'), '', 0.001);
+        $this->assertEqualsDelta($now, $dt->format('U.u'), 0.001);
     }
 
     public function testReadQDateTimeNow()
@@ -506,6 +506,17 @@ class FunctionalTest extends TestCase
         $reader = new Reader($in);
 
         $dt = $reader->readQDateTime();
-        $this->assertEquals($now, $dt->format('U.u'), '', 0.001);
+        $this->assertEqualsDelta($now, $dt->format('U.u'), 0.001);
+    }
+
+    public function assertEqualsDelta($expected, $actual, $delta, $message = '')
+    {
+        if (method_exists($this, 'assertEqualsWithDelta')) {
+            // PHPUnit 7.5+
+            $this->assertEqualsWithDelta($expected, $actual, $delta, $message);
+        } else {
+            // legacy PHPUnit 4 - PHPUnit 7.4
+            $this->assertEquals($expected, $actual, $message, $delta);
+        }
     }
 }

--- a/tests/ReaderTest.php
+++ b/tests/ReaderTest.php
@@ -67,47 +67,43 @@ class ReaderTest extends TestCase
         $this->assertEquals($midnight, $value);
     }
 
-    /**
-     * @expectedException UnderflowException
-     */
     public function testReadBeyondLimitThrows()
     {
         $in = "\x00\x00";
 
         $reader = new Reader($in);
+
+        $this->setExpectedException('UnderflowException');
         $reader->readInt();
     }
 
-    /**
-     * @expectedException UnderflowException
-     */
     public function testReadUintBeyondLimitThrows()
     {
         $in = "\x00\x00";
 
         $reader = new Reader($in);
+
+        $this->setExpectedException('UnderflowException');
         $reader->readUInt();
     }
 
-    /**
-     * @expectedException UnexpectedValueException
-     */
     public function testQVariantTypeUnknown()
     {
         $in = "\x00\x00\x00\x00" . "\x00";
 
         $reader = new Reader($in);
+
+        $this->setExpectedException('UnexpectedValueException');
         $reader->readQVariant();
     }
 
-    /**
-     * @expectedException UnexpectedValueException
-     */
     public function testQUserTypeUnknown()
     {
         $in = "\x00\x00\x00\x7F" . "\x00" . "\x00\x00\x00\x05" . "demo\x00" . "\x00\x00\x00\xFF";
 
         $reader = new Reader($in);
+
+        $this->setExpectedException('UnexpectedValueException');
         $reader->readQVariant();
     }
 
@@ -119,14 +115,13 @@ class ReaderTest extends TestCase
         $this->assertFalse($reader->readBool());
     }
 
-    /**
-     * @expectedException UnderflowException
-     */
     public function testBoolBeyondLimitThrows()
     {
         $in = "";
 
         $reader = new Reader($in);
+
+        $this->setExpectedException('UnderflowException');
         $this->assertFalse($reader->readBool());
     }
 
@@ -215,5 +210,22 @@ class ReaderTest extends TestCase
         $ref->setValue($reader, false);
 
         $this->assertEquals($expected, $reader->readQString());
+    }
+
+    public function setExpectedException($exception, $exceptionMessage = '', $exceptionCode = null)
+    {
+        if (method_exists($this, 'expectException')) {
+            // PHPUnit 5.2+
+            $this->expectException($exception);
+            if ($exceptionMessage !== '') {
+                $this->expectExceptionMessage($exceptionMessage);
+            }
+            if ($exceptionCode !== null) {
+                $this->expectExceptionCode($exceptionCode);
+            }
+        } else {
+            // legacy PHPUnit 4 - PHPUnit 5.1
+            parent::setExpectedException($exception, $exceptionMessage, $exceptionCode);
+        }
     }
 }

--- a/tests/TypesTest.php
+++ b/tests/TypesTest.php
@@ -32,11 +32,26 @@ class TypesTest extends TestCase
         $this->assertEquals(Types::TYPE_QDATETIME, Types::getTypeByValue(new \DateTime()));
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testInvalidType()
     {
+        $this->setExpectedException('InvalidArgumentException');
         Types::getNameByType(123456);
+    }
+
+    public function setExpectedException($exception, $exceptionMessage = '', $exceptionCode = null)
+    {
+        if (method_exists($this, 'expectException')) {
+            // PHPUnit 5.2+
+            $this->expectException($exception);
+            if ($exceptionMessage !== '') {
+                $this->expectExceptionMessage($exceptionMessage);
+            }
+            if ($exceptionCode !== null) {
+                $this->expectExceptionCode($exceptionCode);
+            }
+        } else {
+            // legacy PHPUnit 4 - PHPUnit 5.1
+            parent::setExpectedException($exception, $exceptionMessage, $exceptionCode);
+        }
     }
 }

--- a/tests/WriterTest.php
+++ b/tests/WriterTest.php
@@ -7,7 +7,10 @@ use PHPUnit\Framework\TestCase;
 
 class WriterTest extends TestCase
 {
-    public function setUp()
+    /**
+     * @before
+     */
+    public function setUpWriter()
     {
         $this->writer = new Writer(array(
             'year' => function ($data, Writer $writer) {
@@ -236,11 +239,9 @@ class WriterTest extends TestCase
         $this->assertEquals("\x00\x00\x00\x85\x00" . "\x07\xDF", (string)$this->writer);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testQVariantNullCanNotBeSerialized()
     {
+        $this->setExpectedException('InvalidArgumentException');
         $this->writer->writeQVariant(null);
     }
 
@@ -280,11 +281,26 @@ class WriterTest extends TestCase
         $this->assertEquals("\x00\x00\x00\x05" . "user\x00" . "\x00\x0A" . "\x00\x00\x00\x08" . "\x00t\x00e\x00s\x00t", (string)$this->writer);
     }
 
-    /**
-     * @expectedException UnexpectedValueException
-     */
     public function testQUserTypeInvalid()
     {
+        $this->setExpectedException('UnexpectedValueException');
         $this->writer->writeQUserTypeByName(10, 'unknown');
+    }
+
+    public function setExpectedException($exception, $exceptionMessage = '', $exceptionCode = null)
+    {
+        if (method_exists($this, 'expectException')) {
+            // PHPUnit 5.2+
+            $this->expectException($exception);
+            if ($exceptionMessage !== '') {
+                $this->expectExceptionMessage($exceptionMessage);
+            }
+            if ($exceptionCode !== null) {
+                $this->expectExceptionCode($exceptionCode);
+            }
+        } else {
+            // legacy PHPUnit 4 - PHPUnit 5.1
+            parent::setExpectedException($exception, $exceptionMessage, $exceptionCode);
+        }
     }
 }


### PR DESCRIPTION
PHPUnit 9.3 released a new schema for the `phpunit.xml` configuration file. I had to migrate the file to the new format in order to avoid the warning. PHPUnit Versions older than 9.3 have to use the `phpunit.xml.legacy` configuration file, because the new format is unknown for them.
For further details concerning this pull request look into https://github.com/graphp/graphviz/pull/46.

It's also possible to run this code with PHP 8 🎉